### PR TITLE
bug: fix context

### DIFF
--- a/docker/all-docker-compose.yaml
+++ b/docker/all-docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     restart: always
     build: 
       context: ../
-      dockerfile: ../dockerfile.notes
+      dockerfile: dockerfile.notes
     ports:
       - 8080:8080
     labels:
@@ -29,7 +29,7 @@ services:
     restart: always
     build: 
       context: ../
-      dockerfile: ../dockerfile.calendar
+      dockerfile: dockerfile.calendar
     labels:
        - com.datadoghq.tags.service="calendar"
        - com.datadoghq.tags.env="dev"


### PR DESCRIPTION
- both the context and dockerfile made use of ../

I saw an error

```
failed to solve: failed to read dockerfile: open dockerfile.calendar: no such file or directory
```

when running

```shell
docker-compose -f all-docker-compose.yaml up -d
```
following the instructions on
[exercising the sample application](https://docs.datadoghq.com/tracing/guide/tutorial-enable-go-containers/#starting-and-exercising-the-sample-application)