### PR TITLE
Fix PUT Request Example for Updating Notes in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Otherwise, build and run the main.go file inside each directory to run the corre
 
 [{"id":1,"description":"hello"}]
 
-`curl -X PUT ‘localhost:8080/notes/1/desc=UpdatedNote’`
+`curl -X PUT 'localhost:8080/notes/1?desc=UpdatedNote'`
 
 {"id":1,"description":"UpdatedNote"}
 


### PR DESCRIPTION
https://github.com/DataDog/apm-tutorial-golang/issues/8

This pull request corrects the example for the PUT request used to update notes in the documentation. The previous example incorrectly used a path parameter for the `desc` field, which resulted in a `404 page not found` error during execution. The corrected example now uses a query parameter for the `desc` field, ensuring the request works as intended.

#### Changes:
- Updated the documentation to reflect the correct PUT request example.
- Ensured that the new request format is compatible with the API and performs the note update successfully.

#### Testing:
- Verified that the corrected request updates the note's description as expected via a `curl` command.
